### PR TITLE
Simplify directory normalization, cache same as windbg

### DIFF
--- a/main.go
+++ b/main.go
@@ -282,7 +282,7 @@ func main() {
 			log.Println(string(debugDir.SymbolName)+":", pdbGuid, pdbAgeStr, downloadURL)
 
 			// Create directory for saving symbol file.
-			downloadDir := filepath.Join(saveDirectory, pdbName, strings.ToUpper(pdbGuidStr)+strings.ToUpper(pdbAgeStr), "/")
+			downloadDir := filepath.Join(saveDirectory, pdbName, strings.ToUpper(pdbGuidStr)+strings.ToUpper(pdbAgeStr))
 			err = os.MkdirAll(downloadDir, 0755)
 			if err != nil {
 				log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -241,10 +241,6 @@ func main() {
 		}
 		saveDirectory = filepath.Dir(absPath)
 	}
-	if saveDirectory[len(saveDirectory)-1] == '\\' ||
-		saveDirectory[len(saveDirectory)-1] == '/' {
-		saveDirectory = saveDirectory[:len(saveDirectory)-1]
-	}
 
 	// Check if the given PE path exists.
 	if _, err := os.Stat(pePath); os.IsNotExist(err) {
@@ -273,12 +269,9 @@ func main() {
 				log.Fatal(err)
 			}
 
-			// Get the PDB name.
-			pdbName := string(debugDir.SymbolName)
-			slashIdx := strings.LastIndexByte(pdbName, byte('\\'))
-			if slashIdx >= 0 {
-				pdbName = pdbName[slashIdx+1:]
-			}
+			// Get the PDB filename.
+			fullPdbPath := string(debugDir.SymbolName)
+			pdbName := filepath.Base(fullPdbPath)
 
 			// Get the PDB age string.
 			pdbAgeStr := strconv.FormatUint(uint64(debugDir.InfoPdb70.Age), 16)
@@ -289,14 +282,14 @@ func main() {
 			log.Println(string(debugDir.SymbolName)+":", pdbGuid, pdbAgeStr, downloadURL)
 
 			// Create directory for saving symbol file.
-			downloadDir := saveDirectory + "/" + pdbName + "/" + pdbGuidStr + "/" + pdbAgeStr + "/"
+			downloadDir := filepath.Join(saveDirectory, pdbName, strings.ToUpper(pdbGuidStr)+strings.ToUpper(pdbAgeStr), "/")
 			err = os.MkdirAll(downloadDir, 0755)
 			if err != nil {
 				log.Fatal(err)
 			}
 
-			// Download the symbol file.
-			downloadPath := downloadDir + pdbName
+			// Download the symbol file. FilePath concatenates guid and age
+			downloadPath := filepath.Join(downloadDir, pdbName)
 			err = downloadSymbolFile(downloadPath, downloadURL)
 			if err != nil {
 				log.Fatal(err)


### PR DESCRIPTION
* Removes manual path concatenation and folder normalization and uses std golang routines instead. This nicely shows the preview path with the correct slash in the console output.
* Changes download folder to not put a slash before the age, and to capitalize the GUID+AGE to mimic how windbg (symsrv) caches the pdb files. 

Ex output paths (windows):
```
Before: /kernel32.pdb/dbe09e71b3709cb722c55e5573fa7be1/1/kernel32.pdb
After: \kernel32.pdb\DBE09E71B3709CB722C55E5573FA7BE11\kernel32.pdb
```

My windbg symbol cache:
![image](https://user-images.githubusercontent.com/6619205/147714199-67bdc480-f2ef-4a35-85e4-432031cd31b3.png)